### PR TITLE
Update sqlite3 dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "express": "~3.4.0",
     "jade": "~0.35.0",
-    "sqlite3": "~2.1.17"
+    "sqlite3": "^3.0.8"
   },
   "engines": [
     "node = 0.8.x"


### PR DESCRIPTION
On Linux, 'npm install' fails on installing sqlite3 when compiling native code.
Updating the dependency to last one solve the issue.